### PR TITLE
Bump proc-macro2 to fix compilation on latest nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
proc-macro2 currently fails to build on latest nightly with a bunch of errors like this:

```
~/code/evremap master λ cargo +nightly build
   Compiling proc-macro2 v1.0.47
error[E0422]: cannot find struct, variant or union type `LineColumn` in crate `proc_macro`
   --> /home/hailey/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.47/src/wrapper.rs:479:33
    |
479 |                 let proc_macro::LineColumn { line, column } = s.start();
    |                                 ^^^^^^^^^^ not found in `proc_macro`
    |
help: consider importing one of these items
    |
1   + use crate::LineColumn;
    |
1   + use crate::fallback::LineColumn;
    |
help: if you import `LineColumn`, refer to it directly
    |
479 -                 let proc_macro::LineColumn { line, column } = s.start();
479 +                 let LineColumn { line, column } = s.start();
    |
```