### PR TITLE
Add support for relative and absolute input remapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,42 @@ input = ["KEY_F8"]
 output = ["KEY_MUTE"]
 ```
 
+`REL_*` and `ABS_*` input types are also supported. These have an associated 
+positive or negative value depending on the relative direction of the input.
+You can optionally specify the relative direction by appending a "+" or "-" 
+to the input name. For example, if you wanted to remap your scroll wheel to 
+a keypress:
+
+```toml
+[[remap]]
+input = ["REL_WHEEL+"]
+output = ["KEY_UP"]
+
+[[remap]]
+input = ["REL_WHEEL-"]
+output = ["KEY_DOWN"]
+```
+
+Mapping relative inputs to relative inputs is also possible, you can include 
+a scaling factor to both the input value and output. The input value is divided 
+by the input scaling factor, and the output is multiplied by the output scaling 
+factor. Specify a negative scale factor on the output to invert the input. If you 
+provide an input scale, you need to remap both relative directions separately:
+
+```toml
+[[remap]]
+input = ["REL_WHEEL"]
+output = ["REL_X-2"]
+
+[[remap]]
+input = ["REL_HWHEEL_HI_RES+4"]
+output = ["REL_Y+2"]
+
+[[remap]]
+input = ["REL_HWHEEL_HI_RES-4"]
+output = ["REL_Y+2"]
+```
+
 * How do I list available input devices?
   `sudo evremap list-devices`
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,12 @@
-use crate::mapping::*;
-use crate::remapper::*;
-use anyhow::{Context, Result};
 use std::path::PathBuf;
 use std::time::Duration;
+
+use anyhow::{Context, Result};
 use clap::Parser;
+use evdev_rs::enums::{EV_ABS, EV_KEY, EV_REL};
+
+use crate::mapping::*;
+use crate::remapper::InputMapper;
 
 mod deviceinfo;
 mod mapping;
@@ -40,10 +43,13 @@ enum Opt {
 }
 
 pub fn list_keys() -> Result<()> {
-    let mut keys: Vec<String> = EventCode::EV_KEY(KeyCode::KEY_RESERVED)
+    let mut keys: Vec<String> = EventCode::EV_KEY(EV_KEY::KEY_RESERVED)
         .iter()
+        .chain(EventCode::EV_REL(EV_REL::REL_X).iter()).chain(EventCode::EV_ABS(EV_ABS::ABS_X).iter())
         .filter_map(|code| match code {
             EventCode::EV_KEY(_) => Some(format!("{}", code)),
+            EventCode::EV_REL(_) => Some(format!("{}", code)),
+            EventCode::EV_ABS(_) => Some(format!("{}", code)),
             _ => None,
         })
         .collect();


### PR DESCRIPTION
This is my first foray into Rust so please forgive any egregious convention violations. I am happy to fix any.

I have added the ability to remap relative and absolute inputs. This is primarily useful to remap the mouse wheel of my mouse.

This PR should resolve https://github.com/wez/evremap/issues/14