### PR TITLE
Allow specifying device name in command line args

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,12 @@ enum Opt {
         /// Number of seconds for user to release keys on startup
         #[arg(short, long, default_value = "2")]
         delay: f64,
+
+        /// Name of device to listen to. Overrides device_name in config.
+        device_name: Option<String>,
+
+        /// Optional PCI device path. Overrides phys in config.
+        phys: Option<String>,
     },
 }
 
@@ -71,7 +77,7 @@ fn main() -> Result<()> {
     match opt {
         Opt::ListDevices => deviceinfo::list_devices(),
         Opt::ListKeys => list_keys(),
-        Opt::Remap { config_file, delay } => {
+        Opt::Remap { device_name, phys, config_file, delay } => {
             let mapping_config = MappingConfig::from_file(&config_file).context(format!(
                 "loading MappingConfig from {}",
                 config_file.display()
@@ -81,8 +87,8 @@ fn main() -> Result<()> {
             std::thread::sleep(Duration::from_secs_f64(delay));
 
             let device_info = deviceinfo::DeviceInfo::with_name(
-                &mapping_config.device_name,
-                mapping_config.phys.as_deref(),
+                &device_name.or(mapping_config.device_name).expect("Must provide device_name on command line or in config"),
+                phys.or(mapping_config.phys).as_deref(),
             )?;
 
             let mut mapper = InputMapper::create_mapper(device_info.path, mapping_config.mappings)?;

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 
 #[derive(Debug, Clone)]
 pub struct MappingConfig {
-    pub device_name: String,
+    pub device_name: Option<String>,
     pub phys: Option<String>,
     pub mappings: Vec<Mapping>,
 }
@@ -114,7 +114,7 @@ impl Into<Mapping> for RemapConfig {
 
 #[derive(Debug, Deserialize)]
 struct ConfigFile {
-    device_name: String,
+    device_name: Option<String>,
     #[serde(default)]
     phys: Option<String>,
 


### PR DESCRIPTION
```
Usage: evremap remap [OPTIONS] <CONFIG-FILE> [DEVICE_NAME] [PHYS]

Arguments:
  <CONFIG-FILE>  Specify the configuration file to be loaded
  [DEVICE_NAME]  Name of device to listen to. Overrides device_name in config
  [PHYS]         Optional PCI device path. Overrides phys in config

Options:
  -d, --delay <DELAY>  Number of seconds for user to release keys on startup [default: 2]
  -h, --help           Print help
```

Resolves https://github.com/wez/evremap/issues/17