### PR TITLE
add path option to select device

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ device_name = "AT Translated Set 2 keyboard"
 # specify the `phys` value that is printed by the `list-devices` subcommand
 # phys = "usb-0000:07:00.3-2.1.1/input0"
 
+# If you specify path, device_name and phys are ignored
+# path = "/dev/input/by-id/usb-SINO_WEALTH_Gaming_KB-event-kbd"
+
 # Configure CAPSLOCK as a Dual Role key.
 # Holding it produces LEFTCTRL, but tapping it
 # will produce ESC.

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -10,6 +10,7 @@ pub struct MappingConfig {
     pub device_name: Option<String>,
     pub phys: Option<String>,
     pub mappings: Vec<Mapping>,
+    pub path: Option<String>,
 }
 
 impl MappingConfig {
@@ -30,6 +31,7 @@ impl MappingConfig {
             device_name: config_file.device_name,
             phys: config_file.phys,
             mappings,
+            path: config_file.path,
         })
     }
 }
@@ -116,6 +118,9 @@ impl Into<Mapping> for RemapConfig {
 struct ConfigFile {
     #[serde(default)]
     device_name: Option<String>,
+
+    #[serde(default)]
+    path: Option<String>,
 
     #[serde(default)]
     phys: Option<String>,


### PR DESCRIPTION
It was not able to select the right device using `device_name` and `phys`. So I added an option to select device by path. `/dev/input/by-id/*` provides path which remain same for the same device. So it can be useful is some case.