### PR TITLE
Enhance error message for device name lookup error

### DIFF
--- a/src/deviceinfo.rs
+++ b/src/deviceinfo.rs
@@ -47,9 +47,9 @@ impl DeviceInfo {
         if devices_with_name.is_empty() {
             bail!(
                 "No device found with name `{}`\
-                    This can happen with multiple devices with the same name.
-                    if this is the case please use 'phys=\"{}\"' to disambiguate \
-                    Of you're unsure of the physical port use 'evremap list-devices'", name);
+                    This can happen with multiple devices with the same name. \
+                    If this is the case please use 'phys=\"{}\"' to disambiguate. \
+                    If you're unsure of the physical port use 'evremap list-devices'", name);
         }
 
         if devices_with_name.len() > 1 {

--- a/src/deviceinfo.rs
+++ b/src/deviceinfo.rs
@@ -45,7 +45,11 @@ impl DeviceInfo {
             .collect();
 
         if devices_with_name.is_empty() {
-            bail!("No device found with name `{}`", name);
+            bail!(
+                "No device found with name `{}`\
+                    This can happen with multiple devices with the same name.
+                    if this is the case please use 'phys=\"{}\"' to disambiguate \
+                    Of you're unsure of the physical port use 'evremap list-devices'", name);
         }
 
         if devices_with_name.len() > 1 {


### PR DESCRIPTION
Updated error message to provide additional guidance on disambiguating devices with the same name, as an error like that has happened to me with certain EWEADN keyboards.
not a fix, just a change in error message that might help users.